### PR TITLE
Use us instead of µs

### DIFF
--- a/zpool-iostat-viz
+++ b/zpool-iostat-viz
@@ -44,13 +44,13 @@ def short_time_and_color(ns):
         color = TIME_ANSI_COLORS[5]
 
     if ns < 800:
-        return "{: 7.0f}ns".format(ns), color
+        return "{: 7.0f} ns".format(ns), color
     elif ns < 800000:
-        return "{: 7.2f}us".format(ns/1000), color
+        return "{: 7.2f} us".format(ns/1000), color
     elif ns < 1000000000:
-        return "{: 7.2f}ms".format(ns/1000/1000), color
+        return "{: 7.2f} ms".format(ns/1000/1000), color
     else:
-        return "{: 7.2f}s".format(ns/1000/1000/1000), color
+        return "{: 7.2f} s".format(ns/1000/1000/1000), color
 
 
 def get_stats(pool_names, filename=None):

--- a/zpool-iostat-viz
+++ b/zpool-iostat-viz
@@ -46,7 +46,7 @@ def short_time_and_color(ns):
     if ns < 800:
         return "{: 7.0f}ns".format(ns), color
     elif ns < 800000:
-        return "{: 7.2f}µs".format(ns/1000), color
+        return "{: 7.2f}us".format(ns/1000), color
     elif ns < 1000000000:
         return "{: 7.2f}ms".format(ns/1000/1000), color
     else:


### PR DESCRIPTION
Due to problem with font, we should use `us` which stand for microsecond instead of `µs`

![image](https://user-images.githubusercontent.com/1851037/140292932-7398362a-da43-413e-a72c-6fd3e3231410.png)
