### PR TITLE
Add new functionality and a man-page in mdoc format

### DIFF
--- a/zpool-iostat-viz
+++ b/zpool-iostat-viz
@@ -19,7 +19,10 @@ import sys
 EMPTY_COLORS = (238, 8)
 EMPTY_CHAR = "|"
 PALETTES = list(range(start, end+(second-start), second-start) for second, start, end in ((63, 27, 207), (87, 51, 231), (116, 123, 88), (220, 226, 196), (224, 231, 196), (80, 51, 196), (77, 40, 225), (225, 231, 201), (243, 240, 255), (227, 226, 231), (27, 21, 51)))
-DISPLAY_CHARS = ".abcdefghijklmnopqrstuvwxyz^"
+DISPLAY_CHARS_LETTERS = ".abcdefghijklmnopqrstuvwxyz^"
+DISPLAY_CHARS_DIGITS = ".0123456789#"
+DISPLAY_CHARS_SYMBOLS = " .:;*#"
+DISPLAY_CHARS = DISPLAY_CHARS_LETTERS
 DIFFL_CLOCK_CHARS = "╷╴╵╶"
 
 DIFFL_STAT_MEMORY = 5
@@ -219,6 +222,13 @@ def render_stats(window, transform, should_show_differential, pool, filename=Non
         elif in_key == curses.KEY_DOWN:
             if diffl_stat_interval_index > 0:
                 diffl_stat_interval_index -= 1
+        elif in_key == ord('d'):
+            should_show_differential = not should_show_differential
+        elif in_key == ord('m'):
+            if transform == stats_as_device_centric:
+                transform = stats_as_measurement_centric
+            else:
+                transform = stats_as_device_centric
         elif in_key == ord('q') or in_key == ord('x') or in_key == 27:
             return
         current += len(stats)
@@ -254,6 +264,8 @@ if __name__ == "__main__":
         arg_parser.add_argument("--from-file", "-f", dest="file", action="store")
         arg_parser.add_argument("--pal-time", "--pt", action="store", metavar="P", default="3", help="palette for time buckets")
         arg_parser.add_argument("--pal-count", "--pc", action="store", metavar="P", default="0", help="palette for bucket populations")
+        arg_parser.add_argument("--digits", action="store_true", help="use digits instead of letters")
+        arg_parser.add_argument("--symbols", action="store_true", help="use digits instead of letters")
         arg_parser.add_argument("parts", metavar="pool/vdev", nargs="*", help="Pools or vdevs to display")
         arg_parser.add_argument("--help-colors", action="store_true", help="see color palettes available")
 
@@ -275,6 +287,11 @@ if __name__ == "__main__":
                 if hex(pi)[2:] == parsed_args["pal_time"]: print("  (time)", end="")
                 print()
             sys.exit(0)
+
+        if parsed_args["digits"]:
+            DISPLAY_CHARS = DISPLAY_CHARS_DIGITS
+        if parsed_args["symbols"]:
+            DISPLAY_CHARS = DISPLAY_CHARS_SYMBOLS
 
         curses.wrapper(lambda window: main(window, parsed_args["diff"], parsed_args["parts"], parsed_args["file"], parsed_args["by"] or "m"))
     except subprocess.CalledProcessError as exc:

--- a/zpool-iostat-viz.1
+++ b/zpool-iostat-viz.1
@@ -1,0 +1,117 @@
+.\"
+.\" SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+.\"
+.\" Copyright (c) 2021 Stefan Eßer <se@FreeBSD.org>
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions and the following disclaimer.
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in the
+.\"    documentation and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+.\" ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+.\" FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+.\" DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+.\" OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+.\" HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+.\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+.\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+.\" SUCH DAMAGE.
+.\"
+.Dd November, 6 2021
+.Dt ZPOOL-IOSTAT-VIZ 1
+.Os
+.Sh NAME
+.Nm zpool-iostat-viz
+.Nd Display ZFS pool latency histogram
+.Sh SYNOPSIS
+.Nm
+.Op Fl d , -diff
+.Op Fl -by Ar d|m
+.Op Fl f Ar file , Fl -from-file Ar file
+.Op Fl -pt Ar palette , Fl -pal-time Ar palette
+.Op Fl -pc Ar palette , Fl -pal-count Ar palette
+.Op Fl -digits
+.Op Fl -symbols
+.Op Fl -help-colors
+.Op Ar parts ...
+.Sh DESCRIPTION
+The
+.Nm
+command displays ZFS pool latency information in a more intuitive format
+than the
+.Xr zpool 8
+command invoked as
+.Dq zpool -r .
+Latency information is displayed in a matrix with shorter latency times
+at the top, longer times at the bottom, and columns for the selected
+pools or devices the pools consist of.
+.Pp
+.Bl -tag -width "--help-colors"
+.It Fl -by Ar d|m
+Slice data by device
+.Pq Fl -by Ar d
+or by measurement
+.Pq Fl -by Ar m .
+Use the left and right arrow keys on your keyboard to select one of the
+available screens.
+.It Fl d , -diff
+Show histogram for 3 seconds intervals instead of counts cumulated
+over the run-time of the program.
+The sampling period can be adjusted with the up and down arrow keys.
+.It Fl -digits
+Use
+.Dq ".0123456789#"
+as histogram values.
+.It Fl -from-file Ar file
+Read values from a file containing the output of:
+
+.Dl zpool iostat -wvHp
+.It Fl -help-colors
+List the available color palettes for the
+.Fl -pc
+and
+.Fl -pt
+options.
+.It Fl -pt Ar palette , Fl -pal-time Ar palette
+Select a color palette for the display of time buckets.
+.It Fl -pc Ar palette , Fl -pal-count Ar palette
+Select a color palette for the display of bucket populationss.
+.It Fl -symbols
+Use
+.Dq " .:;*#"
+as histogram values.
+.It Ar parts
+Select parts or vdevs to display.
+By default, all devices
+.Pq including cache and ZIL devices ,
+the logical elements the pools consists of
+.Pq mirror, raidz1, ...
+and all pools are displayed.
+.El
+.Sh EXIT STATUS
+The
+.Nm
+program always returns an exit status of 0.
+.Sh EXAMPLES
+The following is an example of a typical usage
+of the
+.Nm
+command:
+.Pp
+.Dl "zpool-iostats-viz -d"
+.Pp
+.Dl "zpool-iostats-viz --by d --symbols tank"
+.Sh SEE ALSO
+.Xr zpool 8
+.Sh AUTHORS
+The
+.Nm
+program was written by
+.An Chad Miller Aq Mt chad@cornsilk.net .


### PR DESCRIPTION
I have created a "port" of zpool-iostat-viz in FreeBSD that contains a few changes relative to your version:

The following functionality has been added:

--digits option: while letters give high precision output, it is not
always easy to remember their order, especially with quickly changing
displays. Digits give less resolution, but are easier to interpret.

--symbols option: even less steps, but even more intuitive. Symbols
have been chosen to cover more of the character cell for higher
values. This mode could be combined with a blank white color palette,
since colors tend to reduce the effect of the non-black fraction of
the character cell.

Two interactive commands have been added:

'd': switch --diff mode on or off
'm': toggle between per measurement or per device mode

I have once got a run-time error when toggling modes, but could not
reproduce it in later attempts. AFAIU the program, the state between
updates should be stored in a way that allows to toggle modes at any
time (between updates).

The wording of the man-page would probably benefit from a review by a
native English speaker (which I'm obviously not).