### PR TITLE
Fix program crash on "m" with large value of "current"

### DIFF
--- a/zpool-iostat-viz
+++ b/zpool-iostat-viz
@@ -225,16 +225,19 @@ def render_stats(window, transform, should_show_differential, pool, filename=Non
         elif in_key == ord('d'):
             should_show_differential = not should_show_differential
         elif in_key == ord('m'):
-            current = 0
+            stats = None
             stats_history = []
+            current = 0
+            load_time = None
             if transform == stats_as_device_centric:
                 transform = stats_as_measurement_centric
             else:
                 transform = stats_as_device_centric
         elif in_key == ord('q') or in_key == ord('x') or in_key == 27:
             return
-        current += len(stats)
-        current %= len(stats)
+        if stats:
+            current += len(stats)
+            current %= len(stats)
 
 
 def main(window, should_show_differential, pool, filename, views):

--- a/zpool-iostat-viz
+++ b/zpool-iostat-viz
@@ -225,6 +225,7 @@ def render_stats(window, transform, should_show_differential, pool, filename=Non
         elif in_key == ord('d'):
             should_show_differential = not should_show_differential
         elif in_key == ord('m'):
+            current = 0
             if transform == stats_as_device_centric:
                 transform = stats_as_measurement_centric
             else:

--- a/zpool-iostat-viz
+++ b/zpool-iostat-viz
@@ -226,6 +226,7 @@ def render_stats(window, transform, should_show_differential, pool, filename=Non
             should_show_differential = not should_show_differential
         elif in_key == ord('m'):
             current = 0
+            stats_history = []
             if transform == stats_as_device_centric:
                 transform = stats_as_measurement_centric
             else:


### PR DESCRIPTION
Fix program crash if the "m" command is used and "current" is higher than supported by the current stats array length.

The "m" command has been part of a previous pull request that has been merged. I forgot that the stats array length can change and that the stats_history contents depends on the transform function selected.

This patch fixes this issue. The value of "current" is reset to one that is valid for all possible stats array lengths, and stats_history is reset to an empty array to prevent incompatible data to be used in a difference calculation.